### PR TITLE
fix: show Splash on all platforms

### DIFF
--- a/src/auth/modules/Splash.tsx
+++ b/src/auth/modules/Splash.tsx
@@ -1,14 +1,13 @@
-import { useTranslation } from "react-i18next"
-import { useThemeAnimation } from "data/settings/Theme"
 import { FlexColumn } from "components/layout"
-import { sandbox } from "../scripts/env"
+import { useThemeAnimation } from "data/settings/Theme"
+import { useTranslation } from "react-i18next"
 import styles from "./Splash.module.scss"
 
 const Splash = () => {
   const { t } = useTranslation()
   const animation = useThemeAnimation()
 
-  return !sandbox ? null : (
+  return (
     <FlexColumn gap={20} className={styles.screen}>
       <img src={animation} alt="" width={80} height={80} />
       <h1>{t("Initializing app...")}</h1>


### PR DESCRIPTION
when starting `station`  it takes several seconds to initialize the wallet. During this time nothing is show on the screen and everything in blank. We have a `Splash` component that is visible in Desktop version. I would like to propose to show the same for the web version.  