### PR TITLE
Improve functionality of pagination when viewing proposals in Voting status by only paginating when showing all proposals

### DIFF
--- a/src/pages/gov/ProposalsByStatus.tsx
+++ b/src/pages/gov/ProposalsByStatus.tsx
@@ -36,9 +36,16 @@ const ProposalsByStatus = ({ status }: { status: Proposal.Status }) => {
   const whitelist = whitelistData?.[networkName]
 
   const [showAll, setShowAll] = useState(!!whitelist)
-  const toggle = () => setShowAll((state) => !state)
+  const toggle = () => {
+    setShowAll((state) => !state)
+    setPaginationState(DefaultGovernancePaginationState)
+  }
 
-  const pagination = 6
+  const PAGINATION_LENGTH =
+    status === Proposal.Status.PROPOSAL_STATUS_VOTING_PERIOD && !showAll
+      ? 999
+      : 6
+
   const [paginationState, setPaginationState] = useRecoilState(
     governancePaginationState
   )
@@ -64,7 +71,10 @@ const ProposalsByStatus = ({ status }: { status: Proposal.Status }) => {
   const { data, ...proposalState } = useProposals(status, {
     "pagination.count_total": "true",
     "pagination.reverse": "true",
-    "pagination.limit": String(pagination),
+    "pagination.limit":
+      status === Proposal.Status.PROPOSAL_STATUS_VOTING_PERIOD && !showAll
+        ? "999"
+        : String(PAGINATION_LENGTH),
     "pagination.key": key,
   })
   const [proposalData, paginationData] = data || []
@@ -116,8 +126,8 @@ const ProposalsByStatus = ({ status }: { status: Proposal.Status }) => {
   }
 
   const renderPagination = () => {
-    if (!(pagination && paginationData)) return null
-    const recordTotal = Math.ceil(total / pagination)
+    if (!(PAGINATION_LENGTH && paginationData)) return null
+    const recordTotal = Math.ceil(total / PAGINATION_LENGTH)
 
     if (!recordTotal || recordTotal === 1) return null
     const prevPage = page > 1 ? () => handlePrevious() : undefined


### PR DESCRIPTION
(This same PR is pending on TFL's station repo - https://github.com/terra-money/station/pull/130. Submitting it here to improve pagination behavior on Rebel Station while awaiting TFL merge)

Effectively, this PR accomplishes two things:

- Improves the display of whitelisted proposals on the voting tab by eliminating paging for whitelisted items. Paging is maintained when show all is selected
- Works around the api-side behavior observed when pagination.reverse and pagination.count_total is true where subsequent pages are missing the first record (e.g. the page offset of indexed + 1 ahead of where it should be). Ultimately, I believe the underlying cosmos api issue is resolved in cosmos v0.46 (https://github.com/cosmos/cosmos-sdk/issues/11407)