### PR TITLE
fix: Update logic to determine passing/not passing indicator on proposals to align to documentation and chain

### DIFF
--- a/src/pages/gov/ProposalVotes.tsx
+++ b/src/pages/gov/ProposalVotes.tsx
@@ -199,9 +199,12 @@ const calcTallies = (
       ?.voted || 0
 
   const hasConsent =
+    has(total.voted) &&
+    total.voted > abstained &&
     Number(consent) / (Number(total.voted) - Number(abstained)) >
-    threshold.toNumber()
+      threshold.toNumber()
   const isVetoed =
+    has(total.voted) &&
     Number(veto) / Number(total.voted) > veto_threshold.toNumber()
 
   const isPassing = !isBelowQuorum && !isVetoed && hasConsent

--- a/src/pages/gov/ProposalVotes.tsx
+++ b/src/pages/gov/ProposalVotes.tsx
@@ -182,8 +182,10 @@ const calcTallies = (
     ? { x: quorum.toNumber(), type: "quorum" as const }
     : { x: thresholdX, type: "threshold" as const }
 
-  const consentRatio = list.slice(0, 2).map(({ ratio }) => ratio.byVoted)
-  const isPassing = !isBelowQuorum && BigNumber.sum(...consentRatio).gte(0.5)
+  const yesRatio = list[0].ratio.byVoted
+  const noRatio = list.slice(2, 4).map(({ ratio }) => ratio.byVoted)
+
+  const isPassing = !isBelowQuorum && BigNumber.sum(...noRatio).lte(yesRatio)
 
   return { list, total: { ...total, ratio }, flag, isPassing }
 }

--- a/src/pages/gov/ProposalVotes.tsx
+++ b/src/pages/gov/ProposalVotes.tsx
@@ -42,7 +42,7 @@ const ProposalVotes = ({ id, card }: { id: number; card?: boolean }) => {
     if (!(proposal && tally && tallyParams && pool)) return null
 
     const tallies = calcTallies(tally, tallyParams, pool)
-    const { total, list, flag, isPassing } = tallies
+    const { total, list, flag, isPassing, isVetoed } = tallies
     const { voting_end_time } = proposal
 
     const flagLabel = { quorum: t("Quorum"), threshold: t("Pass threshold") }
@@ -66,6 +66,13 @@ const ProposalVotes = ({ id, card }: { id: number; card?: boolean }) => {
                       <strong className="danger">{t("Not passing...")}</strong>
                     )}
                   </p>
+                  {isVetoed && (
+                    <p>
+                      <strong className="danger">
+                        {t("Exceeds veto threshold...")}
+                      </strong>
+                    </p>
+                  )}
                 </section>
               </article>
             </Col>
@@ -199,5 +206,5 @@ const calcTallies = (
 
   const isPassing = !isBelowQuorum && !isVetoed && hasConsent
 
-  return { list, total: { ...total, ratio }, flag, isPassing }
+  return { list, total: { ...total, ratio }, flag, isPassing, isVetoed }
 }


### PR DESCRIPTION
(This PR is pending with TFL - https://github.com/terra-money/station/pull/132 - submitting here to correct display of passing indicator to align with chain pending TFL merge)

This PR is in reference to https://github.com/terra-money/station/issues/129 by proposing the following changes:

- Re-order the vote types displayed both in summary grid as well as progress bar from Yes, Abstain, No, NoWithVeto to Yes, No, NoWithVeto, Abstain. By adjusting the display order, the passing flag on the progress bar is far more meaningful since abstain votes are not counted in the overall consent calculation.
- Update the logic to calculate the isPassing flag to align with the tallying logic used by the chain (documented at https://docs.terra.money/develop/module-specifications/spec-governance/#tallying)
- Add indicator when proposal exceeds veto threshold