### PR TITLE
Improve existing URL regex for detecting URLs in governance proposal descriptions, to include fuzzy URL matching with or without protocol prefix

### DIFF
--- a/src/txs/gov/SubmitProposalForm.tsx
+++ b/src/txs/gov/SubmitProposalForm.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo } from "react"
+import { ChangeEvent, useCallback, useEffect, useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { useFieldArray, useForm } from "react-hook-form"
 import AddIcon from "@mui/icons-material/Add"
@@ -14,6 +14,7 @@ import { isDenomTerraNative } from "@terra-rebels/kitchen-utils"
 import { readAmount, readDenom, toAmount } from "@terra-rebels/kitchen-utils"
 import { SAMPLE_ADDRESS } from "config/constants"
 import { getAmount, sortCoins } from "utils/coin"
+import { isExempted, isWhitelisted, URL_REGEX } from "utils/gov"
 import { has } from "utils/num"
 import { parseJSON } from "utils/data"
 import { queryKey, useIsClassic } from "data/query"
@@ -101,6 +102,8 @@ const SubmitProposalForm = ({ communityPool, minDeposit }: Props) => {
   const amount = toAmount(input)
   const { fields, append, remove } = useFieldArray({ control, name: "changes" })
   const coinsFieldArray = useFieldArray({ control, name: "coins" })
+  const [hasExternalLink, setHasExternalLink] = useState(false)
+  const [externalLinks, setExternalLinks] = useState("")
 
   /* effect: ParameterChangeProposal */
   const shouldAppendChange =
@@ -373,6 +376,27 @@ const SubmitProposalForm = ({ communityPool, minDeposit }: Props) => {
 
   const agoraURL = isClassic ? "classic-agora.terra.money" : "agora.terra.money"
 
+  const validateDescription = (event: ChangeEvent<HTMLInputElement>) => {
+    const parts = event.target.value.split(URL_REGEX)
+
+    setHasExternalLink(
+      !!parts.filter(
+        (part) =>
+          part.match(URL_REGEX) && !isWhitelisted(part) && !isExempted(part)
+      ).length
+    )
+
+    setExternalLinks(
+      parts
+        .filter(
+          (part) =>
+            part.match(URL_REGEX) && !isWhitelisted(part) && !isExempted(part)
+        )
+        .map((part) => part.replace(/\s/g, ""))
+        .join(", ")
+    )
+  }
+
   return (
     <Tx {...tx}>
       {({ max, fee, submit }) => (
@@ -394,11 +418,6 @@ const SubmitProposalForm = ({ communityPool, minDeposit }: Props) => {
                 {t("Parameters cannot be changed by text proposals")}
               </FormWarning>
             )}
-            <FormWarning>
-              {t(
-                "Links to websites outside the Terra ecosystem will not be displayed"
-              )}
-            </FormWarning>
           </Grid>
 
           <FormItem label={t("Proposal type")} error={errors.type?.message}>
@@ -423,9 +442,17 @@ const SubmitProposalForm = ({ communityPool, minDeposit }: Props) => {
             label={t("Description")}
             error={errors.description?.message}
           >
+            {hasExternalLink && (
+              <FormWarning>
+                {t(
+                  `A potential reference to a website outside the Terra ecosystem was detected. These reference(s) will not be displayed in the proposal description: ${externalLinks}`
+                )}
+              </FormWarning>
+            )}
             <TextArea
               {...register("description", {
                 required: "Description is required",
+                onChange: validateDescription,
               })}
               placeholder={t(
                 "We're proposing to spend 100,000 LUNA from the Community Pool to fund the creation of public goods for the Terra ecosystem"

--- a/src/utils/gov.ts
+++ b/src/utils/gov.ts
@@ -1,0 +1,24 @@
+export const isWhitelisted = (url?: string) => {
+  if (!url) return false
+  if (!url.match(/https?:\/\/.*/)) {
+    url = `https://${url}`
+  }
+
+  try {
+    return new URL(url).hostname.endsWith("terra.money")
+  } catch (error) {
+    return false
+  }
+}
+
+/* exempted URLs are displayed as written (but not linked) */
+export const isExempted = (url?: string) => {
+  const exempted = ["terra.py"]
+  if (!url) return false
+
+  return exempted.includes(url.toLowerCase())
+}
+
+/* include 2 and 3 character domains + .money as anchor TLDs for url detection; based on https://data.iana.org/TLD/tlds-alpha-by-domain.txt */
+export const URL_REGEX =
+  /((?:https?:\/\/)?(?:[A-Z0-9-]+?\s*\.\s*)*?(?:\b[A-Z0-9-]{1,63}?)(?:(?:\s*\.(?:am|an|as|at|be|by|do|it|in|is|how|new|no|one|so|top|to))|(?:\s*\.\s*(?:ads|afl|app|axa|ac|ad|ae|af|ag|ai|al|ao|aq|ar|au|aw|ax|az|bar|bbc|bid|bio|biz|bmw|boo|bzh|ba|bb|bd|bf|bg|bh|bi|bj|bl|bm|bn|bo|bq|br|bs|bt|bv|bw|bz|cab|cal|cat|cbn|ceo|cfd|com|crs|ca|cc|cd|cf|cg|ch|ci|ck|cl|cm|cn|co|cr|cu|cv|cw|cx|cy|cz|dad|day|dev|dnp|de|dj|dk|dm|dz|eat|edu|esq|eus|ec|ee|eg|eh|er|es|et|eu|fan|fit|fly|foo|frl|fi|fj|fk|fm|fo|fr|gal|gdn|gle|gmo|gmx|goo|gop|gov|ga|gb|gd|ge|gf|gg|gh|gi|gl|gm|gn|gp|gq|gr|gs|gt|gu|gw|gy|hiv|hk|hm|hn|hr|ht|hu|ibm|ifm|ing|ink|int|iwc|id|ie|il|im|io|iq|ir|jcb|je|jm|jo|jp|kim|krd|ke|kg|kh|ki|km|kn|kp|kr|kw|ky|kz|lat|lds|la|lb|lc|li|lk|lr|ls|lt|lu|lv|ly|money|mil|mma|moe|mov|mtn|ma|mc|md|me|mf|mg|mh|mk|ml|mm|mn|mo|mp|mq|mr|ms|mt|mu|mv|mw|mx|my|mz|net|ngo|nhk|nra|nrw|ntt|nyc|na|nc|ne|nf|ng|ni|nl|np|nr|nu|nz|ong|onl|ooo|org|ovh|om|pro|pub|pa|pe|pf|pg|ph|pk|pl|pm|pn|pr|ps|pt|pw|py|qa|red|ren|rio|rip|re|ro|rs|ru|rw|sap|sca|scb|sew|sky|soy|sa|sb|sc|sd|se|sg|sh|si|sj|sk|sl|sm|sn|sr|ss|st|su|sv|sx|sy|sz|tax|tel|tui|tc|td|tf|tg|th|tj|tk|tl|tm|tn|tp|tr|tt|tv|tw|z|uno|uol|ua|ug|uk|um|us|uy|uz|vet|va|vc|ve|vg|vi|vn|vu|wed|win|wme|wtc|wtf|wf|ws|xin|xxx|xyz|ye|yt|zip|za|zm|zw))+?\b)(?:\/[^.!,?;"'<>()[\]{}\s\x7F-\xFF]*(?:[.!,?]+[^.!,?;"'<>()[\]{}\s\x7F-\xFF]+)*)?)/gi

--- a/src/utils/gov.ts
+++ b/src/utils/gov.ts
@@ -5,7 +5,8 @@ export const isWhitelisted = (url?: string) => {
   }
 
   try {
-    return new URL(url).hostname.endsWith("terra.money")
+    const hostname = new URL(url).hostname
+    return hostname === "terra.money" || hostname.endsWith(".terra.money")
   } catch (error) {
     return false
   }


### PR DESCRIPTION
The original regex used to detect links in governance proposal descriptions assumed a mandatory protocol (http/https) prefix. A number of scam proposals work around the [external url] flag by omitting the protocol handler, allowing for URLs to be displayed. This PR introduced a fuzzy URL detection regex that attempts to remain neutral toward non-URL phrases, while still flagging possible obfuscated URL patterns with spaces (host.  example. com, or similar).

Specifically, this PR:

- Adjusts the regular expression used to detect URLs to anchor on known 2 and 3 character top level domains, allowing for detection of potentially obfuscated URLs with spaces
- Adjusts display of tooltips in proposal descriptions to include the specific URL that was not displayed
- Adjusts proposal submission form to indicate to user that a potential URL was detected in description input
- Refactors repeated logic functions (isExempted(), isWhitelisted()) to a gov util file referenced by both the description and new governance submission forms to eliminate duplication of code related to URL regex detection