### PR TITLE
React to classic-agora sunset (external url whitelist updates)

### DIFF
--- a/src/pages/gov/ProposalDescription.tsx
+++ b/src/pages/gov/ProposalDescription.tsx
@@ -83,8 +83,11 @@ export default ProposalDescription
 
 const isWhitelisted = (url?: string) => {
   if (!url) return false
+  const hostname = new URL(url).hostname
+
   return (
-    new URL(url).hostname.endsWith("terrarebels.net") ||
-    new URL(url).hostname.endsWith("terra.money")
+    hostname.endsWith("commonwealth.im") ||
+    hostname.endsWith("terrarebels.net") ||
+    hostname.endsWith("terra.money")
   )
 }

--- a/src/pages/gov/ProposalDescription.tsx
+++ b/src/pages/gov/ProposalDescription.tsx
@@ -86,8 +86,8 @@ const isWhitelisted = (url?: string) => {
   const hostname = new URL(url).hostname
 
   return (
-    hostname.endsWith("commonwealth.im") ||
-    hostname.endsWith("terrarebels.net") ||
-    hostname.endsWith("terra.money")
+    hostname === "commonwealth.im" ||
+    hostname.endsWith(".terrarebels.net") ||
+    hostname.endsWith(".terra.money")
   )
 }

--- a/src/pages/gov/ProposalDescription.tsx
+++ b/src/pages/gov/ProposalDescription.tsx
@@ -83,11 +83,19 @@ export default ProposalDescription
 
 const isWhitelisted = (url?: string) => {
   if (!url) return false
-  const hostname = new URL(url).hostname
 
-  return (
-    hostname === "commonwealth.im" ||
-    hostname.endsWith(".terrarebels.net") ||
-    hostname.endsWith(".terra.money")
-  )
+  try {
+    const { protocol, hostname } = new URL(url)
+
+    return (
+      protocol === "https:" &&
+      (hostname === "commonwealth.im" ||
+        hostname === "terra.money" ||
+        hostname.endsWith(".terra.money") ||
+        hostname === "terrarebels.net" ||
+        hostname.endsWith(".terrarebels.net"))
+    )
+  } catch (e) {
+    return false
+  }
 }

--- a/src/txs/gov/SubmitProposalForm.tsx
+++ b/src/txs/gov/SubmitProposalForm.tsx
@@ -371,7 +371,7 @@ const SubmitProposalForm = ({ communityPool, minDeposit }: Props) => {
     }
   }
 
-  const agoraURL = isClassic ? "classic-agora.terra.money" : "agora.terra.money"
+  const agoraURL = isClassic ? "forums.terrarebels.net" : "agora.terra.money"
 
   return (
     <Tx {...tx}>


### PR DESCRIPTION
React to classic-agora.terra.money sunset by whitelisting commonwealth.im in the external URL system, and remove a reference to classic-agora.terra.money.